### PR TITLE
Refactor CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,27 @@ services:
   - docker
 
 env:
-  - DIR=.    VERSION=latest
-  - DIR=.    VERSION=5.4
-  - DIR=.    VERSION=5.5
-  - DIR=.    VERSION=5.6
-  - DIR=.    VERSION=7.0
-  - DIR=.    VERSION=7.1
-  - DIR=dev/ VERSION=latest
-  - DIR=dev/ VERSION=5.5
-  - DIR=dev/ VERSION=5.6
-  - DIR=dev/ VERSION=7.0
-  - DIR=dev/ VERSION=7.1
-
-before_install:
-- make -C ${DIR} pull VERSION=${VERSION}
+  - VERSION=latest
+  - VERSION=5.4 NO_DEV=1
+  - VERSION=5.4-apache NO_DEV=1
+  - VERSION=5.4-fpm NO_DEV=1
+  - VERSION=5.5
+  - VERSION=5.5-apache
+  - VERSION=5.5-fpm
+  - VERSION=5.6
+  - VERSION=5.6-apache
+  - VERSION=5.6-fpm
+  - VERSION=7.0
+  - VERSION=7.0-apache
+  - VERSION=7.0-fpm
+  - VERSION=7.1
+  - VERSION=7.1-apache
+  - VERSION=7.1-fpm
 
 install:
-- travis_wait 30 make -C ${DIR} build-nopull VERSION=${VERSION}
+- travis_wait 30 make build VERSION=${VERSION}
+- if [ "$NO_DEV" != "1" ]; then travis_wait 30 make -C dev build VERSION=${VERSION}; fi
 
 script:
-- make -C ${DIR} test VERSION=${VERSION}
+- make test VERSION=${VERSION}
+- if [ "$NO_DEV" != "1" ]; then travis_wait 30 make -C dev test VERSION=${VERSION}; fi

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(VERSION),$(filter 5.5 5.6 7.0 7.1 latest, $(VERSION)))
 endif
 
 build:
-	echo " =====> Building $(IMAGE):$(VERSION)..."
+	@echo " =====> Building $(IMAGE):$(VERSION)..."
 	@dir="$(subst -,/,$(VERSION))"; \
 	if [[ "$(VERSION)" == 'latest' ]]; then \
 		dir='.'; \
@@ -42,8 +42,7 @@ build:
 	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
-	@echo 'Testing loaded extensions...'
-	@echo -e " - $(VERSION)... \c"
+	@echo -e "=====> Testing loaded extensions... \c"
 	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
 		echo 'FAIL [Missing image!!!]'; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,6 @@ PARENT_IMAGE := php
 IMAGE := chialab/php
 VERSION ?= latest
 
-# Tags.
-TAGS := $(VERSION)
-ifneq ($(VERSION),latest)
-	# Add `-apache` and `-fpm` suffix.
-	TAGS += $(VERSION)-apache $(VERSION)-fpm
-endif
-
 # Extensions.
 EXTENSIONS := \
 	bcmath \
@@ -40,48 +33,37 @@ ifeq ($(VERSION),$(filter 5.5 5.6 7.0 7.1 latest, $(VERSION)))
 	EXTENSIONS += OPcache
 endif
 
-pull:
-	@for tag in $(TAGS); do \
-		docker pull $(PARENT_IMAGE):$${tag}; \
-	done
-
-build-nopull:
-	@for tag in $(TAGS); do \
-		echo " =====> Building $(IMAGE):$${tag}..."; \
-		dir="$${tag/-//}"; \
-		if [[ "$${tag}" == 'latest' ]]; then \
-			dir='.'; \
-		fi; \
-		docker build --quiet -t $(IMAGE):$${tag} $${dir}; \
-	done
-
-build: pull build-nopull
+build:
+	echo " =====> Building $(IMAGE):$(VERSION)..."
+	@dir="$(subst -,/,$(VERSION))"; \
+	if [[ "$(VERSION)" == 'latest' ]]; then \
+		dir='.'; \
+	fi; \
+	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
 	@echo 'Testing loaded extensions...'
-	@for tag in $(TAGS); do \
-		echo -e " - $${tag}... \c"; \
-		if [[ -z `docker images $(IMAGE) | grep "\s$${tag}\s"` ]]; then \
-			echo 'FAIL [Missing image!!!]'; \
+	@echo -e " - $(VERSION)... \c"
+	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
+		echo 'FAIL [Missing image!!!]'; \
+		exit 1; \
+	fi
+	@modules=`docker run --rm $(IMAGE):$(VERSION) php -m`; \
+	for ext in $(EXTENSIONS); do \
+		if [[ "$${modules}" != *"$${ext}"* ]]; then \
+			echo "FAIL [$${ext}]"; \
 			exit 1; \
-		fi; \
-		modules=`docker run --rm $(IMAGE):$${tag} php -m`; \
-		for ext in $(EXTENSIONS); do \
-			if [[ "$${modules}" != *"$${ext}"* ]]; then \
-				echo "FAIL [$${ext}]"; \
-				exit 1; \
-			fi \
-		done; \
-		if [[ "$${tag}" == *'-apache' ]]; then \
-			apache=`docker run --rm $(IMAGE):$${tag} apache2ctl -M 2> /dev/null`; \
-			if [[ "$${apache}" != *'rewrite_module'* ]]; then \
-				echo 'FAIL [mod_rewrite]'; \
-				exit 1; \
-			fi \
-		fi; \
-		if [[ -z `docker run --rm $(IMAGE):$${tag} composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-			echo 'FAIL [Composer]'; \
-			exit 1; \
-		fi; \
-		echo 'OK'; \
+		fi \
 	done
+	@if [[ "$(VERSION)" == *'-apache' ]]; then \
+		apache=`docker run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
+			echo 'FAIL [mod_rewrite]'; \
+			exit 1; \
+		fi \
+	fi
+	@if [[ -z `docker run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer]'; \
+		exit 1; \
+	fi
+	@echo 'OK'

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -5,13 +5,6 @@ PARENT_IMAGE := chialab/php
 IMAGE := chialab/php-dev
 VERSION ?= latest
 
-# Tags.
-TAGS := $(VERSION)
-ifneq ($(VERSION),latest)
-	# Add `-apache` and `-fpm` suffix.
-	TAGS += $(VERSION)-apache $(VERSION)-fpm
-endif
-
 # Extensions.
 EXTENSIONS := \
 	bcmath \
@@ -41,48 +34,37 @@ ifeq ($(VERSION),$(filter 5.5 5.6 7.0 7.1 latest, $(VERSION)))
 	EXTENSIONS += OPcache
 endif
 
-pull:
-	@for tag in $(TAGS); do \
-		docker pull $(PARENT_IMAGE):$${tag}; \
-	done
-
-build-nopull:
-	@for tag in $(TAGS); do \
-		echo " =====> Building $(IMAGE):$${tag}..."; \
-		dir="$${tag/-//}"; \
-		if [[ "$${tag}" == 'latest' ]]; then \
-			dir='.'; \
-		fi; \
-		docker build --quiet -t $(IMAGE):$${tag} $${dir}; \
-	done
-
-build: pull build-nopull
+build:
+	echo " =====> Building $(IMAGE):$(VERSION)..."
+	@dir="$(subst -,/,$(VERSION))"; \
+	if [[ "$(VERSION)" == 'latest' ]]; then \
+		dir='.'; \
+	fi; \
+	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
 	@echo 'Testing loaded extensions...'
-	@for tag in $(TAGS); do \
-		echo -e " - $${tag}... \c"; \
-		if [[ -z `docker images $(IMAGE) | grep "\s$${tag}\s"` ]]; then \
-			echo 'FAIL [Missing image!!!]'; \
+	@echo -e " - $(VERSION)... \c"
+	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
+		echo 'FAIL [Missing image!!!]'; \
+		exit 1; \
+	fi
+	@modules=`docker run --rm $(IMAGE):$(VERSION) php -m`; \
+	for ext in $(EXTENSIONS); do \
+		if [[ "$${modules}" != *"$${ext}"* ]]; then \
+			echo "FAIL [$${ext}]"; \
 			exit 1; \
-		fi; \
-		modules=`docker run --rm $(IMAGE):$${tag} php -m`; \
-		for ext in $(EXTENSIONS); do \
-			if [[ "$${modules}" != *"$${ext}"* ]]; then \
-				echo "FAIL [$${ext}]"; \
-				exit 1; \
-			fi \
-		done; \
-		if [[ "$${tag}" == *'-apache' ]]; then \
-			apache=`docker run --rm $(IMAGE):$${tag} apache2ctl -M 2> /dev/null`; \
-			if [[ "$${apache}" != *'rewrite_module'* ]]; then \
-				echo 'FAIL [mod_rewrite]'; \
-				exit 1; \
-			fi \
-		fi; \
-		if [[ -z `docker run --rm $(IMAGE):$${tag} composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-			echo 'FAIL [Composer]'; \
-			exit 1; \
-		fi; \
-		echo 'OK'; \
+		fi \
 	done
+	@if [[ "$(VERSION)" == *'-apache' ]]; then \
+		apache=`docker run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
+			echo 'FAIL [mod_rewrite]'; \
+			exit 1; \
+		fi \
+	fi
+	@if [[ -z `docker run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer]'; \
+		exit 1; \
+	fi
+	@echo 'OK'

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -35,7 +35,7 @@ ifeq ($(VERSION),$(filter 5.5 5.6 7.0 7.1 latest, $(VERSION)))
 endif
 
 build:
-	echo " =====> Building $(IMAGE):$(VERSION)..."
+	@echo " =====> Building $(IMAGE):$(VERSION)..."
 	@dir="$(subst -,/,$(VERSION))"; \
 	if [[ "$(VERSION)" == 'latest' ]]; then \
 		dir='.'; \
@@ -43,8 +43,7 @@ build:
 	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
-	@echo 'Testing loaded extensions...'
-	@echo -e " - $(VERSION)... \c"
+	@echo -e "=====> Testing loaded extensions... \c"
 	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
 		echo 'FAIL [Missing image!!!]'; \
 		exit 1; \


### PR DESCRIPTION
This PR refactors CI builds to make tests more atomic and more reliable. This PR resolves #13.

### How it used to be

Let's consider images for PHP 7.1. They used to be tested in two parallel jobs:

- **Job A**: build and test images `chialab/php:7.1`, `chialab/php:7.1-apache` and `chialab/php:7.1-fpm`
- **Job B**: build and test images `chialab/php-dev:7.1`, `chialab/php-dev:7.1-apache` and `chialab/php-dev:7.1-fpm`

This caused two problems:

1) **Job A** did take a very long time to complete, since those images have lots of dependencies that need to be installed, and sometimes timed out.
2) **Job B** did build images on top of the images built in **Job A**, so for new features we had to wait until the images were ready in the Docker Hub before **Job B** could actually do the job.

### How it works now

Let's consider images for PHP 7.1. They are not tested in three parallel jobs:

- **Job A**: build and test images `chialab/php:7.1` and `chialab/php-dev:7.1`
- **Job B**: build and test images `chialab/php:7.1-apache` and `chialab/php-dev:7.1-apache`
- **Job C**: build and test images `chialab/php:7.1-fpm` and `chialab/php-dev:7.1-fpm`

This solves problem 1) because there are now only two images to be built in each job, one of which usually takes a very short time, and it also solves problem 2) because the dev image is built on top of the image built in the previous step.