### PR TITLE
Add PHP 7.2 dev images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
   - VERSION=7.1
   - VERSION=7.1-apache
   - VERSION=7.1-fpm
-  - VERSION=7.2 NO_DEV=1
-  - VERSION=7.2-apache NO_DEV=1
-  - VERSION=7.2-fpm NO_DEV=1
+  - VERSION=7.2
+  - VERSION=7.2-apache
+  - VERSION=7.2-fpm
 
 install:
 - travis_wait 30 make build VERSION=${VERSION}

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps=" \
         libpng12-dev \
         libpq-dev \
         libxml2-dev \
-        php-pear \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap zip \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps=" \
         libpng12-dev \
         libpq-dev \
         libxml2-dev \
-        php-pear \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps=" \
         libpng12-dev \
         libpq-dev \
         libxml2-dev \
-        php-pear \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \

--- a/dev/7.2/Dockerfile
+++ b/dev/7.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM chialab/php:latest
+FROM chialab/php:7.2
 MAINTAINER dev@chialab.it
 
 # Install XDebug.

--- a/dev/7.2/apache/Dockerfile
+++ b/dev/7.2/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM chialab/php:latest
+FROM chialab/php:7.2-apache
 MAINTAINER dev@chialab.it
 
 # Install XDebug.

--- a/dev/7.2/fpm/Dockerfile
+++ b/dev/7.2/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM chialab/php:latest
+FROM chialab/php:7.2-fpm
 MAINTAINER dev@chialab.it
 
 # Install XDebug.

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -25,6 +25,10 @@ EXTENSIONS := \
 	soap \
 	Xdebug \
 	zip
+ifeq (,$(findstring $(PHP_VERSION), 7.2 latest))
+	# Add more extensions to PHP < 7.2.
+	EXTENSIONS += mcrypt
+endif
 ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql

--- a/dev/README.md
+++ b/dev/README.md
@@ -23,6 +23,9 @@ For more production-like environments, you might want to choose an [image *witho
 - [`7.1` (_dev/7.1/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.1/Dockerfile)
 - [`7.1-apache` (_dev/7.1/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.1/apache/Dockerfile)
 - [`7.1-fpm` (_dev/7.1/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.1/fpm/Dockerfile)
+- [`7.2` (_dev/7.2/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/Dockerfile)
+- [`7.2-apache` (_dev/7.2/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/apache/Dockerfile)
+- [`7.2-fpm` (_dev/7.2/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 


### PR DESCRIPTION
This PR closes #25.

**New images**:
 - `chialab/php-dev:7.2`
 - `chialab/php-dev:7.2-apache`
 - `chialab/php-dev:7.2-fpm`

**Updated images**:
 - `chialab/php-dev:latest` (from PHP 7.1 to PHP 7.2)

**Other changes**:
 - removed `php-pear` from 5.x images — but why was it installed in the first place? 😕
 - added missing assertion on `mcrypt` for `chialab/php-dev` images