### PR TITLE
Tidy up XDebug versions

### DIFF
--- a/dev/5.5/Dockerfile
+++ b/dev/5.5/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.5
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.5/apache/Dockerfile
+++ b/dev/5.5/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.5-apache
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.5/fpm/Dockerfile
+++ b/dev/5.5/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.5-fpm
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.6/Dockerfile
+++ b/dev/5.6/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.6/apache/Dockerfile
+++ b/dev/5.6/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6-apache
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.6/fpm/Dockerfile
+++ b/dev/5.6/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6-fpm
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.5.5 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/Dockerfile
+++ b/dev/7.2/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/apache/Dockerfile
+++ b/dev/7.2/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2-apache
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/fpm/Dockerfile
+++ b/dev/7.2/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2-fpm
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:latest
 MAINTAINER dev@chialab.it
 
 # Install XDebug.
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini


### PR DESCRIPTION
This PR closes #28.

Installed XDebug versions are:
 - **2.4.1** for PHP 5.4
 - **2.5.5** for PHP 5.5 and PHP 5.6
 - **2.6.0** for PHP 7.x