### PR TITLE
Use native composer home

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -34,6 +34,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -34,6 +34,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -34,6 +34,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -34,6 +34,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -34,6 +34,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -32,6 +32,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -33,6 +33,5 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -32,6 +32,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,5 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-ENV COMPOSER_HOME /root/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV PATH $(composer config --global home)/vendor/bin:$PATH


### PR DESCRIPTION
Some services like Bitbucket use default configuration for the most common usages, for example the default cache points to the default composer cache dir:

https://confluence.atlassian.com/bitbucket/caching-dependencies-895552876.html

Altering the defaults parameters of composer with a custom `$COMPOSER_HOME` generates friction in the integration.

Ok, nothing that can't be solved with additional configuration, but if we can use defaults I think we should :smiley: 