### PR TITLE
Fix builds

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER dev@chialab.it
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
+        default-libmysqlclient-dev \
         libbz2-dev \
         libmemcached-dev \
-        libmysqlclient-dev \
         libsasl2-dev \
     " \
     runtimeDeps=" \
@@ -17,7 +17,7 @@ RUN buildDeps=" \
         libldap2-dev \
         libmcrypt-dev \
         libmemcachedutil2 \
-        libpng12-dev \
+        libpng-dev \
         libpq-dev \
         libxml2-dev \
     " \


### PR DESCRIPTION
This PR fixes builds for PHP 5.6, 7.0 and 7.1 images.

Builds were broken due to the fact that the underlying operating system has been updated, and the packages `libpng12-dev` and `libmysqlclient-dev` were not available anymore.

They've been replaced by `libpng-dev` and `default-libmysqlclient-dev`, respectively.