### PR TITLE
Hide Composer warning for commands run as super-user

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.4
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.4-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -37,4 +37,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.4-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.5
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -37,4 +37,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.5-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.5-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.6
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.6-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -37,4 +37,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.6-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.0
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.0-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -37,4 +37,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.0-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.1
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -37,4 +37,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.1-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.1-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -35,4 +35,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.2
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -36,4 +36,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.2-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.2-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -35,4 +35,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:latest
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN buildDeps=" \
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && ln -s $(composer config --global home) /root/composer
-ENV PATH $PATH:/root/composer/vendor/bin
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/dev/5.4/Dockerfile
+++ b/dev/5.4/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.4
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.4.1 \

--- a/dev/5.4/apache/Dockerfile
+++ b/dev/5.4/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.4-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.4.1 \

--- a/dev/5.4/fpm/Dockerfile
+++ b/dev/5.4/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.4-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.4.1 \

--- a/dev/5.5/Dockerfile
+++ b/dev/5.5/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.5
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/5.5/apache/Dockerfile
+++ b/dev/5.5/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.5-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/5.5/fpm/Dockerfile
+++ b/dev/5.5/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.5-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/5.6/Dockerfile
+++ b/dev/5.6/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.6
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/5.6/apache/Dockerfile
+++ b/dev/5.6/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.6-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/5.6/fpm/Dockerfile
+++ b/dev/5.6/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:5.6-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug-2.5.5 \

--- a/dev/7.0/Dockerfile
+++ b/dev/7.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.0
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.0/apache/Dockerfile
+++ b/dev/7.0/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.0-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.0/fpm/Dockerfile
+++ b/dev/7.0/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.0-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.1/Dockerfile
+++ b/dev/7.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.1
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.1/apache/Dockerfile
+++ b/dev/7.1/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.1-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.1/fpm/Dockerfile
+++ b/dev/7.1/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.1-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.2/Dockerfile
+++ b/dev/7.2/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.2
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.2/apache/Dockerfile
+++ b/dev/7.2/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.2-apache
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/7.2/fpm/Dockerfile
+++ b/dev/7.2/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:7.2-fpm
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM chialab/php:latest
-MAINTAINER dev@chialab.it
+LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
 RUN pecl install xdebug \


### PR DESCRIPTION
This PR resolves #44 by setting `COMPOSER_ALLOW_SUPERUSER=1` in the environment as suggested by @Toflar.

This PR also closes #24, as deprecated `MAINTAINER` instructions have now been replaced by label `maintainer`. The email address has been updated, too.