### PR TITLE
PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ env:
   - VERSION=7.2
   - VERSION=7.2-apache
   - VERSION=7.2-fpm
+  - VERSION=7.3 NO_DEV=1
+  - VERSION=7.3-apache NO_DEV=1
+  - VERSION=7.3-fpm NO_DEV=1
 
 install:
 - travis_wait 30 make build VERSION=${VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-language: ruby
+language: minimal
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ env:
   - VERSION=7.2
   - VERSION=7.2-apache
   - VERSION=7.2-fpm
-  - VERSION=7.3 NO_DEV=1
-  - VERSION=7.3-apache NO_DEV=1
-  - VERSION=7.3-fpm NO_DEV=1
+  - VERSION=7.3
+  - VERSION=7.3-apache
+  - VERSION=7.3-fpm
 
 install:
 - travis_wait 30 make build VERSION=${VERSION}

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-rc
+FROM php:7.3
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,0 +1,39 @@
+FROM php:7.3-rc
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+        default-libmysqlclient-dev \
+        libbz2-dev \
+        libmemcached-dev \
+        libsasl2-dev \
+    " \
+    runtimeDeps=" \
+        curl \
+        git \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmemcachedutil2 \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libzip-dev \
+    " \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap \
+    && docker-php-ext-install exif \
+    && pecl install memcached redis \
+    && docker-php-ext-enable memcached.so redis.so \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -r /var/lib/apt/lists/*
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-rc-apache
+FROM php:7.3-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:7.3-rc-apache
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+        default-libmysqlclient-dev \
+        libbz2-dev \
+        libmemcached-dev \
+        libsasl2-dev \
+    " \
+    runtimeDeps=" \
+        curl \
+        git \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmemcachedutil2 \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libzip-dev \
+    " \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap \
+    && docker-php-ext-install exif \
+    && pecl install memcached redis \
+    && docker-php-ext-enable memcached.so redis.so \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -r /var/lib/apt/lists/* \
+    && a2enmod rewrite
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-rc-fpm
+FROM php:7.3-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -1,0 +1,39 @@
+FROM php:7.3-rc-fpm
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+        default-libmysqlclient-dev \
+        libbz2-dev \
+        libmemcached-dev \
+        libsasl2-dev \
+    " \
+    runtimeDeps=" \
+        curl \
+        git \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libldap2-dev \
+        libmemcachedutil2 \
+        libpng-dev \
+        libpq-dev \
+        libxml2-dev \
+        libzip-dev \
+    " \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap \
+    && docker-php-ext-install exif \
+    && pecl install memcached redis \
+    && docker-php-ext-enable memcached.so redis.so \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -r /var/lib/apt/lists/*
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN buildDeps=" \
         libpng-dev \
         libpq-dev \
         libxml2-dev \
+        libzip-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ EXTENSIONS := \
 	redis \
 	soap \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ For development environments, you might want to choose an [image with XDebug ins
 - [`7.2` (_7.2/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.2/Dockerfile)
 - [`7.2-apache` (_7.2/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.2/apache/Dockerfile)
 - [`7.2-fpm` (_7.2/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.2/fpm/Dockerfile)
+- [`7.3` (_7.3/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/Dockerfile)
+- [`7.3-apache` (_7.3/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/apache/Dockerfile)
+- [`7.3-fpm` (_7.3/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 
@@ -44,7 +47,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `gd`
 - `ldap`
 - `mbstring`
-- `mcrypt`
+- `mcrypt` (_only PHP ≤ 7.1_)
 - `memcached`
 - `mysql` (_only PHP 5.x_)
 - `mysqli`

--- a/dev/7.3/Dockerfile
+++ b/dev/7.3/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.3
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug-2.7.0beta1 \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.3/apache/Dockerfile
+++ b/dev/7.3/apache/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.3-apache
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug-2.7.0beta1 \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.3/fpm/Dockerfile
+++ b/dev/7.3/fpm/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.3-fpm
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug-2.7.0beta1 \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:latest
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.7.0beta1 \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -27,11 +27,11 @@ EXTENSIONS := \
 	soap \
 	Xdebug \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/dev/README.md
+++ b/dev/README.md
@@ -29,6 +29,9 @@ For more production-like environments, you might want to choose an [image *witho
 - [`7.2` (_dev/7.2/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/Dockerfile)
 - [`7.2-apache` (_dev/7.2/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/apache/Dockerfile)
 - [`7.2-fpm` (_dev/7.2/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.2/fpm/Dockerfile)
+- [`7.3` (_dev/7.3/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/Dockerfile)
+- [`7.3-apache` (_dev/7.3/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/apache/Dockerfile)
+- [`7.3-fpm` (_dev/7.3/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 
@@ -45,7 +48,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `gd`
 - `ldap`
 - `mbstring`
-- `mcrypt`
+- `mcrypt` (_only PHP ≤ 7.1_)
 - `memcached`
 - `mysql` (_only PHP 5.x_)
 - `mysqli`


### PR DESCRIPTION
This PR closes #45 by adding the usual images for PHP 7.3.

Things to do before getting this PR merged:
- [x] Investigate and fix problems with `memcached` extension (php-memcached-dev/php-memcached#408) — a patch has been pushed to master but not yet released on PECL.
- [x] Change `FROM php:7.3-rc` and remove the `-rc` suffix.
- [ ] Update XDebug version from `2.7.0beta1` to a stable version.
- [x] Update the `latest` image.