### PR TITLE
Build Docker images on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,54 @@
-sudo: required
+sudo: 'required'
 
-language: minimal
+language: 'minimal'
 
 services:
-  - docker
+  - 'docker'
 
 env:
-  - VERSION=latest
-  - VERSION=5.4
-  - VERSION=5.4-apache
-  - VERSION=5.4-fpm
-  - VERSION=5.5
-  - VERSION=5.5-apache
-  - VERSION=5.5-fpm
-  - VERSION=5.6
-  - VERSION=5.6-apache
-  - VERSION=5.6-fpm
-  - VERSION=7.0
-  - VERSION=7.0-apache
-  - VERSION=7.0-fpm
-  - VERSION=7.1
-  - VERSION=7.1-apache
-  - VERSION=7.1-fpm
-  - VERSION=7.2
-  - VERSION=7.2-apache
-  - VERSION=7.2-fpm
-  - VERSION=7.3
-  - VERSION=7.3-apache
-  - VERSION=7.3-fpm
+  - 'VERSION=latest'
+  - 'VERSION=5.4'
+  - 'VERSION=5.4-apache'
+  - 'VERSION=5.4-fpm'
+  - 'VERSION=5.5'
+  - 'VERSION=5.5-apache'
+  - 'VERSION=5.5-fpm'
+  - 'VERSION=5.6'
+  - 'VERSION=5.6-apache'
+  - 'VERSION=5.6-fpm'
+  - 'VERSION=7.0'
+  - 'VERSION=7.0-apache'
+  - 'VERSION=7.0-fpm'
+  - 'VERSION=7.1'
+  - 'VERSION=7.1-apache'
+  - 'VERSION=7.1-fpm'
+  - 'VERSION=7.2'
+  - 'VERSION=7.2-apache'
+  - 'VERSION=7.2-fpm'
+  - 'VERSION=7.3'
+  - 'VERSION=7.3-apache'
+  - 'VERSION=7.3-fpm'
 
 install:
-- travis_wait 30 make build VERSION=${VERSION}
-- if [ "$NO_DEV" != "1" ]; then make -C dev build VERSION=${VERSION}; fi
+  - 'travis_wait 30 make build VERSION=${VERSION}'
+  - '[ "$NO_DEV" = "1" ] || make -C dev build VERSION=${VERSION}'
 
 script:
-- make test VERSION=${VERSION}
-- if [ "$NO_DEV" != "1" ]; then make -C dev test VERSION=${VERSION}; fi
+  - 'make test VERSION=${VERSION}'
+  - '[ "$NO_DEV" = "1" ] || make -C dev test VERSION=${VERSION}'
+
+before_deploy:
+  - 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin'
+
+deploy:
+  - provider: 'script'
+    script: 'make push VERSION=${VERSION}'
+    on:
+      repo: 'Chialab/docker-php'
+      branch: 'master'
+  - provider: 'script'
+    script: 'make -C dev push VERSION=${VERSION}'
+    on:
+      repo: 'Chialab/docker-php'
+      branch: 'master'
+      condition: '"$NO_DEV" != "1"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,11 @@ deploy:
   - provider: 'script'
     script: 'make push VERSION=${VERSION}'
     on:
-      repo: 'Chialab/docker-php'
+      repo: 'chialab/docker-php'
       branch: 'master'
   - provider: 'script'
     script: 'make -C dev push VERSION=${VERSION}'
     on:
-      repo: 'Chialab/docker-php'
+      repo: 'chialab/docker-php'
       branch: 'master'
       condition: '"$NO_DEV" != "1"'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-.PHONY: pull build-nopull build test
+ALL: build
+.PHONY: build test push
 
 PARENT_IMAGE := php
 IMAGE := chialab/php
@@ -41,15 +42,15 @@ build:
 	if [[ "$(VERSION)" == 'latest' ]]; then \
 		dir='.'; \
 	fi; \
-	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
+	docker image build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
 	@echo -e "=====> Testing loaded extensions... \c"
-	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
+	@if [[ -z `docker image ls $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
 		echo 'FAIL [Missing image!!!]'; \
 		exit 1; \
 	fi
-	@modules=`docker run --rm $(IMAGE):$(VERSION) php -m`; \
+	@modules=`docker container run --rm $(IMAGE):$(VERSION) php -m`; \
 	for ext in $(EXTENSIONS); do \
 		if [[ "$${modules}" != *"$${ext}"* ]]; then \
 			echo "FAIL [$${ext}]"; \
@@ -57,14 +58,17 @@ test:
 		fi \
 	done
 	@if [[ "$(VERSION)" == *'-apache' ]]; then \
-		apache=`docker run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		apache=`docker container run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
 		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
 			echo 'FAIL [mod_rewrite]'; \
 			exit 1; \
 		fi \
 	fi
-	@if [[ -z `docker run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
 		echo 'FAIL [Composer]'; \
 		exit 1; \
 	fi
 	@echo 'OK'
+
+push:
+	docker image push $(IMAGE):$(VERSION)

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-.PHONY: pull build-nopull build test
+ALL: build
+.PHONY: build test push
 
 PARENT_IMAGE := chialab/php
 IMAGE := chialab/php-dev
@@ -42,15 +43,15 @@ build:
 	if [[ "$(VERSION)" == 'latest' ]]; then \
 		dir='.'; \
 	fi; \
-	docker build --quiet -t $(IMAGE):$(VERSION) $${dir}
+	docker image build --quiet -t $(IMAGE):$(VERSION) $${dir}
 
 test:
 	@echo -e "=====> Testing loaded extensions... \c"
-	@if [[ -z `docker images $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
+	@if [[ -z `docker image ls $(IMAGE) | grep "\s$(VERSION)\s"` ]]; then \
 		echo 'FAIL [Missing image!!!]'; \
 		exit 1; \
 	fi
-	@modules=`docker run --rm $(IMAGE):$(VERSION) php -m`; \
+	@modules=`docker container run --rm $(IMAGE):$(VERSION) php -m`; \
 	for ext in $(EXTENSIONS); do \
 		if [[ "$${modules}" != *"$${ext}"* ]]; then \
 			echo "FAIL [$${ext}]"; \
@@ -58,14 +59,17 @@ test:
 		fi \
 	done
 	@if [[ "$(VERSION)" == *'-apache' ]]; then \
-		apache=`docker run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		apache=`docker container run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
 		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
 			echo 'FAIL [mod_rewrite]'; \
 			exit 1; \
 		fi \
 	fi
-	@if [[ -z `docker run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
 		echo 'FAIL [Composer]'; \
 		exit 1; \
 	fi
 	@echo 'OK'
+
+push:
+	docker image push $(IMAGE):$(VERSION)


### PR DESCRIPTION
This PR changes the strategy for deploying built images to Docker Hub.

Previously, images were built on Docker Hub using Docker's infrastructure, that was slow and instable.

Now, the very same images that are built and tested on Travis CI are pushed to Docker Hub.