### PR TITLE
Feature : Add PHP 7.4 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ env:
   - 'VERSION=7.3'
   - 'VERSION=7.3-apache'
   - 'VERSION=7.3-fpm'
+  - 'VERSION=7.4'
+  - 'VERSION=7.4-apache'
+  - 'VERSION=7.4-fpm'
 
 install:
   - 'travis_wait 30 make build VERSION=${VERSION}'

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:latest
+FROM php:7.4
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.

--- a/7.4/apache/Dockerfile
+++ b/7.4/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:latest
+FROM php:7.4-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.
@@ -32,7 +32,8 @@ RUN buildDeps=" \
     && pecl install memcached redis \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+    && rm -r /var/lib/apt/lists/* \
+    && a2enmod rewrite
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.4/fpm/Dockerfile
+++ b/7.4/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:latest
+FROM php:7.4-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install PHP extensions and PECL modules.

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ EXTENSIONS := \
 	redis \
 	soap \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ For development environments, you might want to choose an [image with XDebug ins
 - [`7.3` (_7.3/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/Dockerfile)
 - [`7.3-apache` (_7.3/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/apache/Dockerfile)
 - [`7.3-fpm` (_7.3/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.3/fpm/Dockerfile)
+- [`7.4` (_7.4/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/Dockerfile)
+- [`7.4-apache` (_7.4/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/apache/Dockerfile)
+- [`7.4-fpm` (_7.4/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 

--- a/dev/7.4/Dockerfile
+++ b/dev/7.4/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.4
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.4/apache/Dockerfile
+++ b/dev/7.4/apache/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.4-apache
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.4/fpm/Dockerfile
+++ b/dev/7.4/fpm/Dockerfile
@@ -1,0 +1,6 @@
+FROM chialab/php:7.4-fpm
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug.
+RUN pecl install xdebug \
+    && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -28,11 +28,11 @@ EXTENSIONS := \
 	soap \
 	Xdebug \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/dev/README.md
+++ b/dev/README.md
@@ -32,6 +32,9 @@ For more production-like environments, you might want to choose an [image *witho
 - [`7.3` (_dev/7.3/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/Dockerfile)
 - [`7.3-apache` (_dev/7.3/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/apache/Dockerfile)
 - [`7.3-fpm` (_dev/7.3/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.3/fpm/Dockerfile)
+- [`7.4` (_dev/7.4/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.4/Dockerfile)
+- [`7.4-apache` (_dev/7.4/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.4/apache/Dockerfile)
+- [`7.4-fpm` (_dev/7.4/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/7.4/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 


### PR DESCRIPTION
Had to add `libonig-dev` package for PHP version 7.4 as mbstring extension requires it.
https://github.com/docker-library/php/issues/880

Had to update extension `gd` configuration
https://github.com/docker-library/docs/commit/b5ae66754b1eb7a5448ba22b7b7d4800700de809