### PR TITLE
Feature: Alpine images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.DS_Store
+.DS_Store
+.idea
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   - 'VERSION=5.6'
   - 'VERSION=5.6-apache'
   - 'VERSION=5.6-fpm'
+  - 'VERSION=5.6-alpine'
+  - 'VERSION=5.6-alpine-apache'
+  - 'VERSION=5.6-alpine-fpm'
   - 'VERSION=7.0'
   - 'VERSION=7.0-apache'
   - 'VERSION=7.0-fpm'
@@ -28,6 +31,9 @@ env:
   - 'VERSION=7.3'
   - 'VERSION=7.3-apache'
   - 'VERSION=7.3-fpm'
+  - 'VERSION=7.3-alpine'
+  - 'VERSION=7.3-alpine-apache'
+  - 'VERSION=7.3-alpine-fpm'
 
 install:
   - 'travis_wait 30 make build VERSION=${VERSION}'

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -1,0 +1,60 @@
+FROM php:5.6-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libmcrypt-dev \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mcrypt \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached-2.2.0 \
+        redis-4.3.0 \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk del .build-deps .phpize-deps
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/alpine/apache/Dockerfile
+++ b/5.6/alpine/apache/Dockerfile
@@ -1,0 +1,78 @@
+FROM php:5.6-fpm-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libmcrypt-dev \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mcrypt \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached-2.2.0 \
+        redis-4.3.0 \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk add --no-cache \
+        apache2 \
+        apache2-ctl \
+        apache2-utils \
+        apache2-proxy \
+        apache2-ssl \
+    && apk del .build-deps .phpize-deps
+
+# Load mod_rewrite and setup FPM
+RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
+    && sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/httpd.conf \
+    && sed -i "s#/var/www/localhost/htdocs#/var/www/html#" /etc/apache2/httpd.conf \
+    && sed -i "s#/var/www/localhost/cgi-bin#/var/www/html/cgi-bin#" /etc/apache2/httpd.conf \
+    && sed -i "/LoadModule mpm_prefork_module/s/^/#/g" /etc/apache2/httpd.conf \
+    && sed -i "/LoadModule mpm_event_module/s/^#//g" /etc/apache2/httpd.conf \
+    && sed -i "s#DirectoryIndex index.html#DirectoryIndex index.php#" /etc/apache2/httpd.conf \
+    && echo "ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/html/$1" >> /etc/apache2/httpd.conf \
+    && echo "ProxyPassMatch ^/(fpm-ping|fpm-status) fcgi://127.0.0.1:9000" >> /etc/apache2/httpd.conf \
+    && mkdir -p /run/apache2
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/5.6/alpine/fpm/Dockerfile
+++ b/5.6/alpine/fpm/Dockerfile
@@ -1,0 +1,60 @@
+FROM php:5.6-fpm-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libmcrypt-dev \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mcrypt \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached-2.2.0 \
+        redis-4.3.0 \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk del .build-deps .phpize-deps
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:7.3-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached \
+        redis \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk del .build-deps .phpize-deps
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.3/alpine/apache/Dockerfile
+++ b/7.3/alpine/apache/Dockerfile
@@ -1,0 +1,76 @@
+FROM php:7.3-fpm-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached \
+        redis \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk add --no-cache \
+        apache2 \
+        apache2-ctl \
+        apache2-utils \
+        apache2-proxy \
+        apache2-ssl \
+    && apk del .build-deps .phpize-deps
+
+# Load mod_rewrite and setup FPM
+RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
+    && sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/httpd.conf \
+    && sed -i "s#/var/www/localhost/htdocs#/var/www/html#" /etc/apache2/httpd.conf \
+    && sed -i "s#/var/www/localhost/cgi-bin#/var/www/html/cgi-bin#" /etc/apache2/httpd.conf \
+    && sed -i "/LoadModule mpm_prefork_module/s/^/#/g" /etc/apache2/httpd.conf \
+    && sed -i "/LoadModule mpm_event_module/s/^#//g" /etc/apache2/httpd.conf \
+    && sed -i "s#DirectoryIndex index.html#DirectoryIndex index.php#" /etc/apache2/httpd.conf \
+    && echo "ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/html/$1" >> /etc/apache2/httpd.conf \
+    && echo "ProxyPassMatch ^/(fpm-ping|fpm-status) fcgi://127.0.0.1:9000" >> /etc/apache2/httpd.conf \
+    && mkdir -p /run/apache2
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/7.3/alpine/fpm/Dockerfile
+++ b/7.3/alpine/fpm/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:7.3-fpm-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install PHP extensions and PECL modules.
+RUN buildDeps=" \
+      bzip2-dev \
+      icu-dev \
+      postgresql-dev \
+      openldap-dev \
+      libmemcached-dev \
+    " \
+    runtimeDeps=" \
+      freetype-dev \
+      libldap \
+      icu-libs \
+      libbz2 \
+      libpng-dev \
+      libjpeg-turbo-dev \
+      libmemcached-libs \
+      libpq \
+      libzip \
+      libxml2-dev \
+      libzip-dev \
+    " \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && apk add --no-cache $runtimeDeps \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache ca-certificates \
+    && docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        exif \
+        iconv \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install \
+        gd \
+        ldap \
+    && pecl install \
+        memcached \
+        redis \
+    && docker-php-ext-enable \
+        memcached \
+        redis \
+    && apk del .build-deps .phpize-deps
+
+# Install Composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && ln -s $(composer config --global home) /root/composer
+ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test:
 		fi \
 	done
 	@if [[ "$(VERSION)" == *'-apache' ]]; then \
-		apache=`docker container run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		apache=`docker container run --rm $(IMAGE):$(VERSION) apachectl -M 2> /dev/null`; \
 		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
 			echo 'FAIL [mod_rewrite]'; \
 			exit 1; \

--- a/dev/5.6/alpine/Dockerfile
+++ b/dev/5.6/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:5.6-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug-2.5.5 \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/5.6/alpine/apache/Dockerfile
+++ b/dev/5.6/alpine/apache/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:5.6-alpine-apache
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug-2.5.5 \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/5.6/alpine/fpm/Dockerfile
+++ b/dev/5.6/alpine/fpm/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:5.6-alpine-fpm
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug-2.5.5 \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/7.3/alpine/Dockerfile
+++ b/dev/7.3/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:7.3-alpine
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/7.3/alpine/apache/Dockerfile
+++ b/dev/7.3/alpine/apache/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:7.3-alpine-apache
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/7.3/alpine/fpm/Dockerfile
+++ b/dev/7.3/alpine/fpm/Dockerfile
@@ -1,0 +1,8 @@
+FROM chialab/php:7.3-alpine-fpm
+LABEL maintainer="dev@chialab.io"
+
+# Install XDebug
+RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del .phpize-deps

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -59,7 +59,7 @@ test:
 		fi \
 	done
 	@if [[ "$(VERSION)" == *'-apache' ]]; then \
-		apache=`docker container run --rm $(IMAGE):$(VERSION) apache2ctl -M 2> /dev/null`; \
+		apache=`docker container run --rm $(IMAGE):$(VERSION) apachectl -M 2> /dev/null`; \
 		if [[ "$${apache}" != *'rewrite_module'* ]]; then \
 			echo 'FAIL [mod_rewrite]'; \
 			exit 1; \


### PR DESCRIPTION
This PR adds Alpine Linux images, which have the main advantage of being much smaller than Debian ones (PHP 7.3 Alpine image is ~140MB).

Had to change `Makefile` to use `apachectl` for testing `rewrite_module` in Alpine Linux. This should be safe because `apachectl` is an alias to `apache2ctl` on Debian.

Apache image uses FPM for memory efficiency, issue the following command from the container to start serving pages:
`$ httpd -D FOREGROUND & php-fpm -F`