### PR TITLE
Fix: PHP 5.x builds

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis zendopcache \
+    && pecl install memcached-2.2.0 redis-4.3.0 zendopcache \
     && docker-php-ext-enable memcached.so redis.so opcache.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis zendopcache \
+    && pecl install memcached-2.2.0 redis-4.3.0 zendopcache \
     && docker-php-ext-enable memcached.so redis.so opcache.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/* \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis zendopcache \
+    && pecl install memcached-2.2.0 redis-4.3.0 zendopcache \
     && docker-php-ext-enable memcached.so redis.so opcache.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/* \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/* \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps=" \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap \
     && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis \
+    && pecl install memcached-2.2.0 redis-4.3.0 \
     && docker-php-ext-enable memcached.so redis.so \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
redis PECL extension dropped PHP 5 support from version 5.0.0, this PR pins version 4.3.0 for PHP 5.x builds