### PR TITLE
Docker PHP Extension Installer

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,37 +1,37 @@
 FROM php:5.6
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis-4.3.0 \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysql \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -1,37 +1,37 @@
 FROM php:5.6-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis-4.3.0 \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysql \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -1,37 +1,37 @@
 FROM php:5.6-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached-2.2.0 redis-4.3.0 \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysql \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.0
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.0-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.0-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.1
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.1-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -1,37 +1,36 @@
 FROM php:7.1-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      mcrypt \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,36 +1,35 @@
 FROM php:7.2
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -1,36 +1,35 @@
 FROM php:7.2-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -1,36 +1,35 @@
 FROM php:7.2-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,37 +1,35 @@
 FROM php:7.3
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -1,37 +1,35 @@
 FROM php:7.3-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -1,37 +1,35 @@
 FROM php:7.3-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,38 +1,35 @@
 FROM php:7.4
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libonig-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/7.4/apache/Dockerfile
+++ b/7.4/apache/Dockerfile
@@ -1,38 +1,35 @@
 FROM php:7.4-apache
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libonig-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/* \
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip \
+# already installed:
+#      iconv \
+#      mbstring \
     && a2enmod rewrite
 
 # Install Composer.

--- a/7.4/fpm/Dockerfile
+++ b/7.4/fpm/Dockerfile
@@ -1,38 +1,35 @@
 FROM php:7.4-fpm
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libonig-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,35 @@
 FROM php:latest
 LABEL maintainer="dev@chialab.io"
 
-# Install PHP extensions and PECL modules.
-RUN buildDeps=" \
-        default-libmysqlclient-dev \
-        libbz2-dev \
-        libmemcached-dev \
-        libsasl2-dev \
-    " \
-    runtimeDeps=" \
-        curl \
-        git \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmemcachedutil2 \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libonig-dev \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install gd \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap \
-    && docker-php-ext-install exif \
-    && pecl install memcached redis \
-    && docker-php-ext-enable memcached.so redis.so \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
+# Download script to install PHP extensions and dependencies
+ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
+
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+      curl \
+      git \
+    && install-php-extensions \
+      bcmath \
+      bz2 \
+      calendar \
+      exif \
+      gd \
+      intl \
+      ldap \
+      memcached \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      pgsql \
+      redis \
+      soap \
+      zip
+# already installed:
+#      iconv \
+#      mbstring \
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/dev/5.6/Dockerfile
+++ b/dev/5.6/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug-2.5.5 \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.6/apache/Dockerfile
+++ b/dev/5.6/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug-2.5.5 \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/5.6/fpm/Dockerfile
+++ b/dev/5.6/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:5.6-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug-2.5.5 \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.0/Dockerfile
+++ b/dev/7.0/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.0
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.0/apache/Dockerfile
+++ b/dev/7.0/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.0-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.0/fpm/Dockerfile
+++ b/dev/7.0/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.0-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.1/Dockerfile
+++ b/dev/7.1/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.1
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.1/apache/Dockerfile
+++ b/dev/7.1/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.1-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.1/fpm/Dockerfile
+++ b/dev/7.1/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.1-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/Dockerfile
+++ b/dev/7.2/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/apache/Dockerfile
+++ b/dev/7.2/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.2/fpm/Dockerfile
+++ b/dev/7.2/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.2-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.3/Dockerfile
+++ b/dev/7.3/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.3
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.3/apache/Dockerfile
+++ b/dev/7.3/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.3-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.3/fpm/Dockerfile
+++ b/dev/7.3/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.3-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.4/Dockerfile
+++ b/dev/7.4/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.4
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.4/apache/Dockerfile
+++ b/dev/7.4/apache/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.4-apache
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/7.4/fpm/Dockerfile
+++ b/dev/7.4/fpm/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:7.4-fpm
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,5 +2,5 @@ FROM chialab/php:latest
 LABEL maintainer="dev@chialab.io"
 
 # Install XDebug.
-RUN pecl install xdebug \
+RUN install-php-extensions xdebug \
     && echo "zend_extension=\"$(php-config --extension-dir)/xdebug.so\"" > $PHP_INI_DIR/conf.d/xdebug.ini


### PR DESCRIPTION
This PR introduces an [external script](https://github.com/mlocati/docker-php-extension-installer) to handle installing PHP extensions and their dependencies.

This lowers the image sizes to ~440 MB by installing better tailored dependencies.

ref: #60 