### PR TITLE
✨ Added zip & unzip (fixes Composer's warning when install/update deps)

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
     runtimeDeps=" \
         curl \
         git \
+        zip unzip \
         libfreetype6-dev \
         libicu-dev \
         libjpeg-dev \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.4/apache/Dockerfile
+++ b/7.4/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/7.4/fpm/Dockerfile
+++ b/7.4/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
       curl \
       git \
+      zip unzip \
     && install-php-extensions \
       bcmath \
       bz2 \


### PR DESCRIPTION
Fixes warning: "As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
Installing 'unzip' may remediate them." - resolves #48 

Sizes (will be compressed during Docker image build):
* zip +623 kB
* unzip +580 kB

libzip is required to be installed, because PHP zip extension depends on it, but libzip already pre-installed, it handled by:
https://github.com/mlocati/docker-php-extension-installer/blob/1deeb6d6560663cc956e970fda5f87cf163e3528/install-php-extensions#L637
and
https://github.com/mlocati/docker-php-extension-installer/blob/1deeb6d6560663cc956e970fda5f87cf163e3528/install-php-extensions#L934