### PR TITLE
✨ Added `sockets` extension

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -23,7 +23,7 @@ RUN buildDeps=" \
         libxslt1-dev \
     " \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip \
+    && docker-php-ext-install bcmath bz2 calendar iconv intl mbstring mcrypt mysql mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip sockets \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -29,7 +29,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -29,7 +29,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -28,7 +28,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -29,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -28,7 +28,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -28,7 +28,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -29,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -28,7 +28,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -28,6 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -28,6 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.4/apache/Dockerfile
+++ b/7.4/apache/Dockerfile
@@ -28,6 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       soap \
       xsl \
       zip \
+      sockets \
 # already installed:
 #      iconv \
 #      mbstring \

--- a/7.4/fpm/Dockerfile
+++ b/7.4/fpm/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       redis \
       soap \
       xsl \
-      zip
+      zip \
+      sockets
 # already installed:
 #      iconv \
 #      mbstring \

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,10 @@ EXTENSIONS := \
 	pdo_pgsql \
 	pgsql \
 	redis \
-    soap \
-    xsl \
-    zip
+	soap \
+	xsl \
+	zip \
+	sockets
 ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `xsl`
 - `Zend OPcache`
 - `zip`
+- `sockets`
 
 You will probably not need all this stuff. Even if having some extra extensions loaded ain't a big issue in most cases, you will very likely want to checkout this repository, remove unwanted extensions from the `Dockerfile`, and build your own image — for sometimes removing is easier than adding. 😉
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -27,7 +27,8 @@ EXTENSIONS := \
 	redis \
 	soap \
 	Xdebug \
-	zip
+	zip \
+	sockets
 ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt


### PR DESCRIPTION
This PR provides `sockets` PHP extension on all docker images, resolves #65 
`sockets` extension is required by [php-amqplib (PHP client for RabbitMQ)](https://github.com/php-amqplib/php-amqplib).