### PR TITLE
[WIP] 👷 Improved .travis.yml - speed up build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,61 @@
-sudo: 'required'
-
-language: 'minimal'
+os: linux
+dist: bionic
+language: shell
 
 services:
-  - 'docker'
+  - docker
+
+git:
+  depth: 5
+  quiet: true
 
 env:
-  - 'VERSION=latest'
-  - 'VERSION=5.4'
-  - 'VERSION=5.4-apache'
-  - 'VERSION=5.4-fpm'
-  - 'VERSION=5.5'
-  - 'VERSION=5.5-apache'
-  - 'VERSION=5.5-fpm'
-  - 'VERSION=5.6'
-  - 'VERSION=5.6-apache'
-  - 'VERSION=5.6-fpm'
-  - 'VERSION=7.0'
-  - 'VERSION=7.0-apache'
-  - 'VERSION=7.0-fpm'
-  - 'VERSION=7.1'
-  - 'VERSION=7.1-apache'
-  - 'VERSION=7.1-fpm'
-  - 'VERSION=7.2'
-  - 'VERSION=7.2-apache'
-  - 'VERSION=7.2-fpm'
-  - 'VERSION=7.3'
-  - 'VERSION=7.3-apache'
-  - 'VERSION=7.3-fpm'
-  - 'VERSION=7.4'
-  - 'VERSION=7.4-apache'
-  - 'VERSION=7.4-fpm'
+  global:
+    # Enable Docker BuildKit - https://docs.docker.com/develop/develop-images/build_enhancements/
+    # - DOCKER_BUILDKIT=1
+  jobs:
+    - VERSION=latest
+    - VERSION=5.4
+    - VERSION=5.4-apache
+    - VERSION=5.4-fpm
+    - VERSION=5.5
+    - VERSION=5.5-apache
+    - VERSION=5.5-fpm
+    - VERSION=5.6
+    - VERSION=5.6-apache
+    - VERSION=5.6-fpm
+    - VERSION=7.0
+    - VERSION=7.0-apache
+    - VERSION=7.0-fpm
+    - VERSION=7.1
+    - VERSION=7.1-apache
+    - VERSION=7.1-fpm
+    - VERSION=7.2
+    - VERSION=7.2-apache
+    - VERSION=7.2-fpm
+    - VERSION=7.3
+    - VERSION=7.3-apache
+    - VERSION=7.3-fpm
+    - VERSION=7.4
+    - VERSION=7.4-apache
+    - VERSION=7.4-fpm
+
+cache:
+  directories:
+  - docker_images
+
+before_install:
+  # Update Docker to newest version - https://docs.travis-ci.com/user/docker/#installing-a-newer-docker-version
+  # - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  # - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  # - sudo apt-get update
+  # - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  # - docker -v
+  # Load cached Docker images
+  - docker load -i docker_images/images.tar || true
+
+before_cache:
+  - mkdir -p docker_images && docker save -o docker_images/images.tar $(docker images -a -q)
 
 install:
   - 'travis_wait 30 make build VERSION=${VERSION}'


### PR DESCRIPTION
⚠️ PR is in progress, not ready to be approved & merged ⚠️
**Any suggestions/tips are welcome 😃**   
##

This PR brings up improvements for TravisCI - speed up build times:
- [x] `git clone` now clones only 5 latest commits, not 50 as TravisCI [uses as default](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth).
- [x] Git output is now omitted, [`quiet` option](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-quiet)
- [x] Removed deprecated directive `sudo`, switched to Ubuntu 18 (bionic)
- [x] ~~TravisCI [forced to use](https://docs.travis-ci.com/user/docker/#installing-a-newer-docker-version) latest version of Docker~~
└ That increases build time to ~30 secs, so commented out this step in `.travis.yml`
- [x] ~~Switched to better & faster Docker Build system called [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) (18.09 required)~~
└ Docker 18.09 required, but TravisCI provides 18.06, so commented out this step in `.travis.yml`
- [x] Enabled TravisCI caching for all Docker images during CI process
└ Caching intermediate or pulled images produced during Docker Build process, may help to speed up next builds.
Problem here is that each time Docker build completes, new image with unique id produced and will be placed into cache at the end of TravisCI job. That may lead to increase cache-bundle size very fast. So, maybe we need to implement script which will detect if something really changed in contents of built images between TravisCI builds or not, prune old images from cache, then cache latest built images only.
