### PR TITLE
Install both Composer 1 and 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-sudo: 'required'
+os: 'linux'
+dist: 'focal'
 
-language: 'minimal'
+language: 'shell'
 
 services:
   - 'docker'

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -36,11 +36,22 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -37,11 +37,22 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -36,11 +36,22 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -36,11 +36,22 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -37,11 +37,22 @@ RUN buildDeps=" \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -36,11 +36,22 @@ RUN buildDeps=" \
     && rm -r /var/lib/apt/lists/*
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -39,11 +39,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -39,11 +39,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.3/apache/Dockerfile
+++ b/7.3/apache/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.3/fpm/Dockerfile
+++ b/7.3/fpm/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.4/apache/Dockerfile
+++ b/7.4/apache/Dockerfile
@@ -38,11 +38,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
     && a2enmod rewrite
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/7.4/fpm/Dockerfile
+++ b/7.4/fpm/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,22 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
 #      mbstring \
 
 # Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && ln -s $(composer config --global home) /root/composer
-ENV PATH=$PATH:/root/composer/vendor/bin COMPOSER_ALLOW_SUPERUSER=1
-
-# Install prestissimo (composer plugin). Plugin that downloads packages in parallel to speed up the installation process
-# After release of Composer 2.x, remove prestissimo, because parallelism already merged into Composer 2.x branch:
-# https://github.com/composer/composer/pull/7904
-RUN composer global require hirak/prestissimo
+ENV PATH=$PATH:/root/composer2/vendor/bin:/root/composer1/vendor/bin \
+  COMPOSER_ALLOW_SUPERUSER=1 \
+  COMPOSER_HOME=/root/composer2 \
+  COMPOSER1_HOME=/root/composer1
+RUN cd /opt \
+  # Download installer and check for its integrity.
+  && curl -sSL https://getcomposer.org/installer > composer-setup.php \
+  && curl -sSL https://composer.github.io/installer.sha384sum > composer-setup.sha384sum \
+  && sha384sum --check composer-setup.sha384sum \
+  # Install Composer 2 and expose `composer` as a symlink to it.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer2 --2 \
+  && ln -s /usr/local/bin/composer2 /usr/local/bin/composer \
+  # Install Composer 1, make it point to a different `$COMPOSER_HOME` directory than Composer 2, install `hirak/prestissimo` plugin.
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=.composer1 --1 \
+  && printf "#!/bin/sh\nCOMPOSER_HOME=\$COMPOSER1_HOME\nexec /usr/local/bin/.composer1 \$@" > /usr/local/bin/composer1 \
+  && chmod 755 /usr/local/bin/composer1 \
+  && composer1 global require hirak/prestissimo \
+  # Remove installer files.
+  && rm /opt/composer-setup.php /opt/composer-setup.sha384sum

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,20 @@ test:
 			exit 1; \
 		fi \
 	fi
-	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-		echo 'FAIL [Composer]'; \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version 2\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 2]'; \
 		exit 1; \
 	fi
-	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-		echo 'FAIL [Composer plugin - prestissimo]'; \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer2 --version 2> /dev/null | grep '^Composer version 2\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 2]'; \
+		exit 1; \
+	fi
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 --version 2> /dev/null | grep '^Composer version 1\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 1]'; \
+		exit 1; \
+	fi
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 1 plugin - prestissimo]'; \
 		exit 1; \
 	fi
 	@echo 'OK'

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ in addition to those you can already find in the [official PHP image](https://hu
 You will probably not need all this stuff. Even if having some extra extensions loaded ain't a big issue in most cases, you will very likely want to checkout this repository, remove unwanted extensions from the `Dockerfile`, and build your own image — for sometimes removing is easier than adding. 😉
 
 ## Composer
-[Composer](https://getcomposer.org) is installed globally in all images. Please, refer to their documentation for usage hints.  
-[Prestissimo (composer plugin)](https://github.com/hirak/prestissimo) is installed globally in all images. Plugin that downloads packages in parallel to speed up the installation process of Composer packages.
+[Composer](https://getcomposer.org) is installed globally in all images. Please, refer to their documentation for usage hints.
+Since 2020/11/01 both version 1 and 2 are installed, available through `composer1` and `composer2` commands respectively (`composer` in now a symlink to `composer2`).  
+[Prestissimo (composer plugin)](https://github.com/hirak/prestissimo) is installed globally in all images, for use with Composer version 1. It's a plugin that downloads packages in parallel to speed up the installation process of Composer packages.
 
 
 ## Contributing

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -29,7 +29,7 @@ EXTENSIONS := \
 	Xdebug \
 	xsl \
 	zip \
-    sockets
+	sockets
 ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
@@ -70,12 +70,20 @@ test:
 			exit 1; \
 		fi \
 	fi
-	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-		echo 'FAIL [Composer]'; \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer --version 2> /dev/null | grep '^Composer version 2\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 2]'; \
 		exit 1; \
 	fi
-	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
-		echo 'FAIL [Composer prestissimo]'; \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer2 --version 2> /dev/null | grep '^Composer version 2\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 2]'; \
+		exit 1; \
+	fi
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 --version 2> /dev/null | grep '^Composer version 1\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 1]'; \
+		exit 1; \
+	fi
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+		echo 'FAIL [Composer 1 plugin - prestissimo]'; \
 		exit 1; \
 	fi
 	@echo 'OK'


### PR DESCRIPTION
This PR resolves #73 and fixes the systematic build error we're getting right now.

Both `composer1` and `composer2` are installed right now, `composer` being an alias for the latter.
They use separate `$COMPOSER_HOME` directories, although this involves a bit of a workaround. For Composer 1, `hirak/prestissimo` continues to be shipped.

This PR also refreshes an outdated `.travis.yml` syntax, which should resolve a couple of warnings we're getting right now.