### PR TITLE
add the php 8 Dockerfiles to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ For development environments, you might want to choose an [image with XDebug ins
 - [`7.4` (_7.4/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/Dockerfile)
 - [`7.4-apache` (_7.4/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/apache/Dockerfile)
 - [`7.4-fpm` (_7.4/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/7.4/fpm/Dockerfile)
+- [`8.0` (_8.0/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/8.0/Dockerfile)
+- [`8.0-apache` (_8.0/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/8.0/apache/Dockerfile)
+- [`8.0-fpm` (_8.0/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/8.0/fpm/Dockerfile)
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen manteinance.
 


### PR DESCRIPTION
The README makes this image look like it's not maintained anymore because it's the first thing you see when browsing on the docker hub and it was missing the 8.0 images.