### PR TITLE
Remove references to PHP 5.4 and 5.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test:
 		echo 'FAIL [Composer 1]'; \
 		exit 1; \
 	fi
-	@if [[ "$(PHP_VERSION)" != "5.4" && "$(PHP_VERSION)" != "5.5" && -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
 		echo 'FAIL [Composer 1 plugin - prestissimo]'; \
 		exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ For development environments, you might want to choose an [image with XDebug ins
 
 ## Available tags and `Dockerfile` links
 - [`latest` (_Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/Dockerfile)
-- [`5.4` (_5.4/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.4/Dockerfile)
-- [`5.4-apache` (_5.4/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.4/apache/Dockerfile)
-- [`5.4-fpm` (_5.4/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.4/fpm/Dockerfile)
-- [`5.5` (_5.5/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.5/Dockerfile)
-- [`5.5-apache` (_5.5/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.5/apache/Dockerfile)
-- [`5.5-fpm` (_5.5/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.5/fpm/Dockerfile)
 - [`5.6` (_5.6/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.6/Dockerfile)
 - [`5.6-apache` (_5.6/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.6/apache/Dockerfile)
 - [`5.6-fpm` (_5.6/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/5.6/fpm/Dockerfile)

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -79,7 +79,7 @@ test:
 		echo 'FAIL [Composer 1]'; \
 		exit 1; \
 	fi
-	@if [[ "$(PHP_VERSION)" != "5.4" && "$(PHP_VERSION)" != "5.5" && -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
+	@if [[ -z `docker container run --rm $(IMAGE):$(VERSION) composer1 global show 2> /dev/null | grep '^hirak/prestissimo [0-9][0-9]*\.[0-9][0-9]*'` ]]; then \
 		echo 'FAIL [Composer 1 plugin - prestissimo]'; \
 		exit 1; \
 	fi

--- a/dev/README.md
+++ b/dev/README.md
@@ -10,12 +10,6 @@ For more production-like environments, you might want to choose an [image *witho
 
 ## Available tags and `Dockerfile` links
 - [`latest` (_dev/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/Dockerfile)
-- [`5.4` (_dev/5.4/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.4/Dockerfile)
-- [`5.4-apache` (_dev/5.4/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.4/apache/Dockerfile)
-- [`5.4-fpm` (_dev/5.4/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.4/fpm/Dockerfile)
-- [`5.5` (_dev/5.5/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.5/Dockerfile)
-- [`5.5-apache` (_dev/5.5/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.5/apache/Dockerfile)
-- [`5.5-fpm` (_dev/5.5/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.5/fpm/Dockerfile)
 - [`5.6` (_dev/5.6/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.6/Dockerfile)
 - [`5.6-apache` (_dev/5.6/apache/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.6/apache/Dockerfile)
 - [`5.6-fpm` (_dev/5.6/fpm/Dockerfile_)](https://github.com/Chialab/docker-php/blob/master/dev/5.6/fpm/Dockerfile)


### PR DESCRIPTION
This PR removes references to 5.4 and 5.5 images from README and Makefiles, after these images have been discontinued in #85.