### PR TITLE
Install `event` PHP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       bcmath \
       bz2 \
       calendar \
+      event \
       exif \
       gd \
       gettext \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ EXTENSIONS := \
 	bcmath \
 	bz2 \
 	calendar \
+	event \
 	exif \
 	gd \
 	gettext \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `bcmath`
 - `bz2`
 - `calendar`
+- `event`
 - `exif`
 - `gd`
 - `gettext`

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -13,6 +13,7 @@ EXTENSIONS := \
 	bcmath \
 	bz2 \
 	calendar \
+	event \
 	exif \
 	gd \
 	gettext \

--- a/dev/README.md
+++ b/dev/README.md
@@ -61,6 +61,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `bcmath`
 - `bz2`
 - `calendar`
+- `event`
 - `exif`
 - `gd`
 - `gettext`

--- a/xhprof/Makefile
+++ b/xhprof/Makefile
@@ -13,6 +13,7 @@ EXTENSIONS := \
 	bcmath \
 	bz2 \
 	calendar \
+	event \
 	exif \
 	gd \
 	gettext \

--- a/xhprof/README.md
+++ b/xhprof/README.md
@@ -61,6 +61,7 @@ in addition to those you can already find in the [official PHP image](https://hu
 - `bcmath`
 - `bz2`
 - `calendar`
+- `event`
 - `exif`
 - `gd`
 - `gettext`


### PR DESCRIPTION
This MR adds the `event` extension to all PHP images.

This extension is useful for environments that use libraries that rely on `libevent` such as [ReachPHP](https://reactphp.org/).