### PR TITLE
PHP 8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]') }}
     strategy:
       matrix:
-        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         flavor: [ '', '-apache', '-fpm' ]
         include:
           - version: 'latest'
@@ -109,7 +109,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]') }}
     strategy:
       matrix:
-        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         flavor: [ '', '-apache', '-fpm' ]
         include:
           - version: 'latest'

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ For development environments, you might want to choose an [image with XDebug ins
 - `8.1`
 - `8.1-apache`
 - `8.1-fpm`
+- `8.2`
+- `8.2-apache`
+- `8.2-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -34,11 +34,11 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/dev/README.md
+++ b/dev/README.md
@@ -50,6 +50,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.1`
 - `8.1-apache`
 - `8.1-fpm`
+- `8.2`
+- `8.2-apache`
+- `8.2-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/pcov/Makefile
+++ b/pcov/Makefile
@@ -34,7 +34,7 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif

--- a/pcov/README.md
+++ b/pcov/README.md
@@ -44,6 +44,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.1`
 - `8.1-apache`
 - `8.1-fpm`
+- `8.2`
+- `8.2-apache`
+- `8.2-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/xhprof/Makefile
+++ b/xhprof/Makefile
@@ -34,11 +34,11 @@ EXTENSIONS := \
 	xhprof \
 	xsl \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 latest))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/xhprof/README.md
+++ b/xhprof/README.md
@@ -50,6 +50,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.1`
 - `8.1-apache`
 - `8.1-fpm`
+- `8.2`
+- `8.2-apache`
+- `8.2-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 


### PR DESCRIPTION
This PR add PHP 8.2 to built images, as PHP 8.2.0 [has been released yesterday](https://www.php.net/archive/2022.php#2022-12-08-1).