### PR TITLE
PHP 8.3 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]') }}
     strategy:
       matrix:
-        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         flavor: [ '', '-apache', '-fpm', '-alpine', '-fpm-alpine' ]
         include:
           - version: 'latest'
@@ -117,7 +117,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]') }}
     strategy:
       matrix:
-        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         flavor: [ '', '-apache', '-fpm', '-alpine', '-fpm-alpine' ]
         include:
           - version: 'latest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       exif \
       gd \
       gettext \
-      imagick \
       intl \
       ldap \
       memcached \
@@ -48,6 +47,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q \
       5.6.*) PHP_EXTENSIONS="$PHP_EXTENSIONS mcrypt mysql";; \
       7.0.*|7.1.*) PHP_EXTENSIONS="$PHP_EXTENSIONS mcrypt";; \
     esac \
+    # Install Imagick from master on PHP >= 8.3, because imagick 3.7.0 broke on latest PHP releases and Imagick maintainers don't care to tag a newer release
+    && if [ $(php -r 'echo PHP_VERSION_ID;') -lt 80300 ]; then \
+      PHP_EXTENSIONS="$PHP_EXTENSIONS imagick"; \
+      else PHP_EXTENSIONS="$PHP_EXTENSIONS https://api.github.com/repos/Imagick/imagick/tarball/28f27044e435a2b203e32675e942eb8de620ee58"; \
+    fi \
     && install-php-extensions $PHP_EXTENSIONS \
     && if command -v a2enmod; then a2enmod rewrite; fi
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,7 +21,6 @@ RUN apk add --no-cache \
       exif \
       gd \
       gettext \
-      imagick \
       intl \
       ldap \
       memcached \
@@ -40,6 +39,11 @@ RUN apk add --no-cache \
       5.6.*) PHP_EXTENSIONS="$PHP_EXTENSIONS mcrypt mysql";; \
       7.0.*|7.1.*) PHP_EXTENSIONS="$PHP_EXTENSIONS mcrypt";; \
     esac \
+    # Install Imagick from master on PHP >= 8.3, because imagick 3.7.0 broke on latest PHP releases and Imagick maintainers don't care to tag a newer release
+    && if [ $(php -r 'echo PHP_VERSION_ID;') -lt 80300 ]; then \
+      PHP_EXTENSIONS="$PHP_EXTENSIONS imagick"; \
+      else PHP_EXTENSIONS="$PHP_EXTENSIONS https://api.github.com/repos/Imagick/imagick/tarball/28f27044e435a2b203e32675e942eb8de620ee58"; \
+    fi \
     && install-php-extensions $PHP_EXTENSIONS \
     && if command -v a2enmod; then a2enmod rewrite; fi
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ For development environments, you might want to choose an [image with XDebug ins
 - `8.2`
 - `8.2-apache`
 - `8.2-fpm`
+- `8.3`
+- `8.3-apache`
+- `8.3-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -34,11 +34,11 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/dev/README.md
+++ b/dev/README.md
@@ -53,6 +53,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.2`
 - `8.2-apache`
 - `8.2-fpm`
+- `8.3`
+- `8.3-apache`
+- `8.3-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/pcov/Makefile
+++ b/pcov/Makefile
@@ -34,7 +34,7 @@ EXTENSIONS := \
 	xsl \
 	zip \
 	sockets
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif

--- a/pcov/README.md
+++ b/pcov/README.md
@@ -47,6 +47,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.2`
 - `8.2-apache`
 - `8.2-fpm`
+- `8.3`
+- `8.3-apache`
+- `8.3-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 

--- a/xhprof/Makefile
+++ b/xhprof/Makefile
@@ -34,11 +34,11 @@ EXTENSIONS := \
 	xhprof \
 	xsl \
 	zip
-ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to PHP < 7.2.
 	EXTENSIONS += mcrypt
 endif
-ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 latest alpine))
+ifeq (,$(findstring $(PHP_VERSION), 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 latest alpine))
 	# Add more extensions to 5.x series images.
 	EXTENSIONS += mysql
 endif

--- a/xhprof/README.md
+++ b/xhprof/README.md
@@ -53,6 +53,9 @@ For more production-like environments, you might want to choose an [image *witho
 - `8.2`
 - `8.2-apache`
 - `8.2-fpm`
+- `8.3`
+- `8.3-apache`
+- `8.3-fpm`
 
 As you might have guessed, all tags are built on top of the corresponding tag of the official image. Not all tags are supported in order to easen maintenance.
 


### PR DESCRIPTION
This PR adds PHP 8.3 images.

[Release announcement](https://www.php.net/archive/2023.php#2023-11-23-2)

----

EDIT: latest release of Imagick fails randomly to build for PHP 8.3 on alpine/amd64; waiting for them to tag a new release

https://github.com/Imagick/imagick/issues/643
https://github.com/Imagick/imagick/issues/630#issuecomment-1818511778
https://github.com/mlocati/docker-php-extension-installer/pull/811